### PR TITLE
Configuración de multer y cloudinary

### DIFF
--- a/backend/src/config/cloudinary.ts
+++ b/backend/src/config/cloudinary.ts
@@ -1,0 +1,42 @@
+import dotenv from 'dotenv';
+import { v2 as cloudinary } from 'cloudinary';
+import fs from 'fs';
+import path from 'path';
+dotenv.config();
+
+cloudinary.config({
+    cloud_name: process.env.CLOUDINARY_CLOUD_NAME,
+    api_key: process.env.CLOUDINARY_API_KEY,
+    api_secret: process.env.CLOUDINARY_API_SECRET
+});
+
+const uploadToCloudinary = async (localFilePath: string, filename: string) => {
+    try {
+        var folder = "KlowHub-api";
+        var filePathOnCloudinary = folder + "/" + path.parse(filename).name;
+        const result = await cloudinary.uploader.upload(
+            localFilePath,
+            { "public_id": filePathOnCloudinary }
+        )
+        return result;
+    } catch (error) {
+        console.log(error);
+        return { message: "Error al subir a Cloudinary" };
+    } finally {
+        fs.unlinkSync(localFilePath)
+    }
+}
+
+const deleteFromCloudinary = async (publicId: string) => {
+    try {
+        await cloudinary.uploader.destroy(publicId);
+    } catch (error) {
+        console.log(error);
+        return { message: "Error al eliminar de Cloudinary" }
+    }
+}
+
+export default {
+    uploadToCloudinary,
+    deleteFromCloudinary
+};

--- a/backend/src/utils/multer.ts
+++ b/backend/src/utils/multer.ts
@@ -1,0 +1,13 @@
+import multer from 'multer';
+import path from 'path';
+
+const upload = multer({
+  storage: multer.diskStorage({
+    destination: path.join(__dirname, '..', 'public', 'uploads'),
+    filename: (req, file, cb) => {
+      cb(null, file.originalname);
+    },
+  }),
+});
+
+export default upload;


### PR DESCRIPTION
multer para usarlo en la ruta donde se recibe la imagen,
cloudinary para subir la imagen a la nube,

así se usa multer 
(se importa)
import upload from "./utils/multer"

(en la ruta se recibe la imagen)
.post(verifyJWT, upload.single('image'), create)

así se usa cloudinary:
(importa el cloudinary a controlador)
import { uploadToCloudinary, deleteFromCloudinary } from '../config/cloudinary';

    (para crear una imagen en la nube)
    const { path, filename } = req.file;   (recibes la imagen)
    const { url, public_id } = await uploadToCloudinary(path, filename);    (luego la mandas en la función de subir, que es esta y 
     recoge la url de la imagen)

    (luego con la url haces la imagen en la tabla de base de dato de postgress)

    (para eliminarla haces así, buscas la imagen en la tabla y luego le pasa el publicId de la imagen a la otra función así:)
    await deleteFromCloudinary(image.publicId); (espera que se borre)

usa estas variables de entorno:
CLOUDINARY_CLOUD_NAME="KlowHub-Abi"
CLOUDINARY_API_KEY="543233225675957"
CLOUDINARY_API_SECRET="7m5RkbtPmmNgjJJ9gCOSN-zFv_U"